### PR TITLE
fix for: Could not find a declaration file for module 'sim-ecs'. './n…

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,10 @@
   ],
   "exports": {
     ".": {
-      "import": "./dist/sim-ecs.mjs",
+      "import": [
+        "./dist/sim-ecs.mjs",
+        "./dist/index.d.ts"
+      ],
       "require": "./dist/sim-ecs.cjs"
     }
   },


### PR DESCRIPTION
…ode_modules/sim-ecs/dist/sim-ecs.mjs' implicitly has an 'any' type.

  There are types at './node_modules/sim-ecs/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'sim-ecs' library may need to update its package.json or typings.